### PR TITLE
Fixes sass compilation for select component

### DIFF
--- a/src/elements/select/_select.scss
+++ b/src/elements/select/_select.scss
@@ -18,11 +18,10 @@ $use-selects: true !default;
 
     -webkit-appearance: none;
     -moz-appearance: none;
-  }
 
-  &:focus {
-    border-bottom-width: 2px;
-    border-bottom-color: $base-font-color;
+    &:focus {
+      border-bottom-width: 2px;
+      border-bottom-color: $base-font-color;
+    }
   }
-
 }


### PR DESCRIPTION
Fixes SASS compilation error as referenced in #133

`Scss compiler error: Base-level rules cannot contain the parent-selector-referencing character '&'.`